### PR TITLE
Fix character proficiency

### DIFF
--- a/src/character.js
+++ b/src/character.js
@@ -76,7 +76,7 @@ const PROFICIENCY = (() => {
   if (document.querySelector(".ico-weapon-7")) list.push("Melee");
   if (document.querySelector(".ico-weapon-8")) list.push("Bow");
   if (document.querySelector(".ico-weapon-9")) list.push("Harp");
-  if (document.querySelector(".ico-weapon-0")) list.push("Katana");
+  if (document.querySelector(".ico-weapon-10")) list.push("Katana");
   return list.join(",");
 })();
 


### PR DESCRIPTION
Previously after classname with number 9 it goes back to 0. Now in gacha page it uses multiple digits properly resulting in those proficiencies not being detected by the bookmarklet.

This PR updates katana proficiency selector from 0 to 10.