### PR TITLE
Fix weapon name selector

### DIFF
--- a/src/weapon.js
+++ b/src/weapon.js
@@ -8,7 +8,11 @@ if (!location.hash.match("#gacha/weapon")) {
 
 const ID = document.querySelector('.prt-weapon-image > .img-weapon').getAttribute("src").match(/\/g\/(.+?)\./)[1];
 
-const NAME = document.querySelector(".txt-item-name").textContent;
+const NAME = (() => {
+  const largeBanner = document.querySelector(".txt-item-name")?.textContent;
+  const smallBanner = document.querySelector(".prt-weapon-info > div:first-child")?.textContent;
+  return (largeBanner) ? largeBanner : smallBanner;
+})();
 
 const RARITY = (() => {
   if (document.querySelector(".prt-rarity-4")) return "ssr";


### PR DESCRIPTION
Weapon name in the weapon page could be under two different selectors, depending on whether it's multi-row or not (e.g. grand weapons always have `[Grand Weapon]` series text on the first line.

This PR updates the bookmarklet so it can fetch the name of both types.